### PR TITLE
fix use of deprecated gradle features

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,10 @@ plugins {
 
 group = 'com.github.jkatzwinkel'
 version = '0.0.909'
-sourceCompatibility = '17'
+java {
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
+}
 
 publishing {
     publications {


### PR DESCRIPTION
will be removed in gradle 9:

- https://docs.gradle.org/8.4/userguide/upgrading_version_8.html#java_convention_deprecation
- https://docs.gradle.org/8.4/userguide/upgrading_version_8.html#test_framework_implementation_dependencies